### PR TITLE
[BugFix] !init plan !init clean !deck remove

### DIFF
--- a/Scripts/General Scripts/API Commands/Card.js
+++ b/Scripts/General Scripts/API Commands/Card.js
@@ -18,4 +18,11 @@ function flipCardFn([], msg) {
 
 on('ready', () => {
   CentralInput.addCMD(/^!\s*card\s*flip\s*$/i, flipCardFn, true)
+
+  CentralInput.addCMD(/^!\s*card\s*remove\s*$/i, ([], msg) => {
+    eachCard(msg, (character, graphic, card, deck) => {
+      whisper(deckNotification(deck, {"card": card, "status": "Removed"}), {speakingTo: msg.playerid, gmEcho: true})
+      card.remove()
+    }, { min: 1 })
+  }, true)
 })

--- a/Scripts/General Scripts/Functions/EachCharacter.js
+++ b/Scripts/General Scripts/Functions/EachCharacter.js
@@ -9,6 +9,10 @@ function eachCard(msg, givenFunction, options) {
     let deck
 
     let cardid = graphic.get('_cardid')
+    if(!cardid && graphic.get('gmnotes').startsWith('cardid:')) {
+      cardid = graphic.get('gmnotes').replace('cardid:', '')
+    }
+
     if(!cardid && options.cardRequired) {
       whisper("Select only cards for initiative.", {speakingTo: msg.playerid})
       return
@@ -55,12 +59,23 @@ function eachCharacter(msg, givenFunction, options){
   options = options || {}
   if(options.characterRequired == undefined) options.characterRequired = true;
   if(options.defaultCharacter == undefined) options.defaultCharacter = true;
+  if(options.onlyOneCharacter) {
+    options.min = 1
+    options.max = 1
+  }
+  
   if((msg.selected == undefined || msg.selected.length <= 0) && options.defaultCharacter){
     msg.selected = [defaultCharacter(msg.playerid)];
     if(msg.selected[0] == undefined) return;
   }
 
-  if(options.onlyOneCharacter && msg.selected.length != 1) return whisper('Select only one graphic.');
+  if(options.min && (!msg.selected || msg.selected.length < options.min)) {
+    return whisper(`Select at least ${options.min} graphic(s).`);
+  }
+
+  if(options.max != undefined && msg.selected && msg.selected.length > options.max) {
+    return whisper(`Select at most ${options.max} graphic(s).`);
+  }
 
   _.each(msg.selected, function(obj){
     if(obj._type == 'graphic'){

--- a/Scripts/Gloomhaven/API Commands/Initiative.js
+++ b/Scripts/Gloomhaven/API Commands/Initiative.js
@@ -111,13 +111,14 @@ on("ready",function(){
   CentralInput.addCMD(/^!\s*init(?:iative)?\s+clean$/i, () => {
     const turns = new INQTurns({ order: GLOOMHAVEN_INITIATIVE_ORDER })
     turns.turnorder = [turns.toTurnObj('End of Round', 'R0')]
+    turns.save()
     state.INK_GLOOMHAVEN = state.INK_GLOOMHAVEN || {}
-    state.INK_GLOOMHAVEN.player_initiative = {}
-    announceTurn(turns)
+    state.INK_GLOOMHAVEN.playerInitiative = {}
+    announcePlan()
   }, true);
 
   //secretly store's player initaive for use when all players are ready
-  CentralInput.addCMD(/^!\s*init(?:iative)?\s+plan\s*(|\s\S.*)$/i, ([, playername], msg) => {
+  CentralInput.addCMD(/^!\s*init(?:iative)?\s+plan\s*(.*)$/i, ([, playername], msg) => {
     let player = undefined;
     if(playername) {
       let suggestion = '!init plan $'
@@ -128,7 +129,7 @@ on("ready",function(){
       player = getObj('player', msg.playerid)
     }
 
-    const initObj = calcGloomhavenInit(msg)
+    const initObj = calcGloomhavenInit(msg, { player: player })
     if(!initObj) return
     const turns = new INQTurns({ order: GLOOMHAVEN_INITIATIVE_ORDER })
     const turnObj = turns.toTurnObj(initObj.name, `${initObj.first} ${initObj.second}`)

--- a/Scripts/Gloomhaven/Functions/calcGloomhavenInit.js
+++ b/Scripts/Gloomhaven/Functions/calcGloomhavenInit.js
@@ -1,14 +1,9 @@
 //calculate the initiative of currently selected graphics
-function calcGloomhavenInit(msg){
-  if(!msg.selected || msg.selected.length < 1) {
-    whisper("Select at least one graphic.", {speakingTo: msg.playerid})
-    return
-  }
-
+function calcGloomhavenInit(msg, options) {
+  options = options || {}
   var initiativeDetails = []
   eachCard(msg, (character, graphic, card, deck) => {
     let initiativeValue = card.get('name').substring(0,2)
-
     if(!RegExp('^\\d\\d$').test(initiativeValue)) {
       whisper(`Card ${card.get('name')} does not start with a valid initiative value.`)
       return
@@ -20,7 +15,7 @@ function calcGloomhavenInit(msg){
       value: card.get('name').substring(0,2),
       deckname: deck.get('name')
     })
-  })
+  }, { min: 1 })
 
   if(initiativeDetails.length == 1
     && initiativeDetails[0].type == 'Monster') {
@@ -32,12 +27,7 @@ function calcGloomhavenInit(msg){
   } else if(initiativeDetails.length == 2
     && initiativeDetails[0].type == 'Player'
     && initiativeDetails[1].type == 'Player') {
-    let player = getObj('player', msg.playerid)
-    if(!player) {
-      whisper('You the player do not exist. Contacting the gm.', {speakingTo: msg.playerid, gmEcho: true})
-      return
-    }
-
+    let player = options.player || getObj('player', msg.playerid)
     initiativeDetails.sort((a, b) => a.position - b.position)
     return {
       name: player.get('_displayname'),


### PR DESCRIPTION
Provides the following bug fixes
* `!init plan` will now correctly record player initiative for a specified player
* `!init clean` will now empty the turn order
* `!init clean` will now set the Round counter to 0.
* `!init clean` will now remove secret player initiative 
* `!deck add` and `!card remove` now use `eachCard()` which can recognize card imitations.

Provides the following improvements
* `eachCharacter`, `eachGraphic`, `eachCard()` can specify a `min` and `max` for number of items selected.
* `eachCard()` can recognize card imitations as cards (graphics that have gmnotes = `cardid:<cardid>`)
* Added `!card remove` to remove all selected cards from their decks. This replaces `!deck remove <deck>`.