### PR TITLE
Update 0.3

### DIFF
--- a/Scripts/General Scripts/API Commands/Card.js
+++ b/Scripts/General Scripts/API Commands/Card.js
@@ -16,6 +16,82 @@ function flipCardFn([], msg) {
   })
 }
 
+function topCardFn([, whereToPlace], msg) {
+  const placeOnTop = whereToPlace.toLowerCase() == 'top'
+  let deckid = undefined;
+  let sameDeck = true;
+  let cardDetails = []
+  eachCard(msg, (character, graphic, card, deck) => {
+    if(deckid != undefined && deckid != deck.id) {
+      sameDeck = false
+      whisper('All cards must belong to the same deck.', { speakingTo: msg.playerid })
+      return
+    } else if(sameDeck) {
+      deckid = deck.id
+      cardDetails.push({
+        cardid: card.id,
+        left: Number(graphic.get('left')),
+        top: Number(graphic.get('top')),
+        approximation: graphic.get('_subtype') != 'card',
+        graphic: graphic
+      })
+    }
+  }, { min: 1 })
+
+  if(!sameDeck || !deckid) return;
+  cardDetails.sort((cardA, cardB) => {
+    if(cardA.left < cardB.left) {
+      return -1
+    } else if(cardA.left > cardB.left) {
+      return 1
+    } else if(cardA.top < cardB.top) {
+      return -1
+    } else if(cardA.top > cardB.top) {
+      return 1
+    } else {
+      return 0
+    }
+  })
+
+  const deck = getObj('deck', deckid)
+  const cardsInTheDeck = deck.get('_currentDeck').split(',').slice(deck.get('_currentIndex')+1)
+  const cardsInTheDiscard = deck.get('_discardPile').split(',')
+  const cardsToPlaceOnTheDeck = []
+  const cardsToPlaceBelowTheDeck = []
+  _.each(cardDetails, cardDetail => {
+    const cardid = cardDetail.cardid
+    if(placeOnTop) {
+      cardsToPlaceOnTheDeck.push(cardid)
+    } else {
+      cardsToPlaceBelowTheDeck.push(cardid)
+    }
+
+    if(cardDetail.approximation) {
+      cardDetail.graphic.remove()
+      for(let i = 0; i < cardsInTheDiscard.length; i++) {
+        if(cardsInTheDiscard[i] == cardid) {
+          cardsInTheDiscard.splice(i, 1)
+          return
+        }
+      }
+
+      whisper('WARNING: Card Id of approximated card not found in the discard pile. Please contact your GM.', { speakingTo: msg.playerid })
+    } else {
+      pickUpCard(cardid)
+    }
+  })
+
+  const orderedList = [].concat(
+                            cardsInTheDiscard,
+                            cardsToPlaceOnTheDeck,
+                            cardsInTheDeck,
+                            cardsToPlaceBelowTheDeck
+                          )
+
+  shuffleDeck(deckid, true, orderedList)
+  _.each(cardsInTheDiscard, cardInTheDiscard => drawCard(deckid))
+}
+
 on('ready', () => {
   CentralInput.addCMD(/^!\s*card\s*flip\s*$/i, flipCardFn, true)
 
@@ -25,4 +101,6 @@ on('ready', () => {
       card.remove()
     }, { min: 1 })
   }, true)
+
+  CentralInput.addCMD(/!\s*card\s*(top|bottom)\s*$/i, topCardFn, true)
 })

--- a/Scripts/General Scripts/API Commands/Card.js
+++ b/Scripts/General Scripts/API Commands/Card.js
@@ -90,6 +90,7 @@ function topCardFn([, whereToPlace], msg) {
 
   shuffleDeck(deckid, true, orderedList)
   _.each(cardsInTheDiscard, cardInTheDiscard => hackyDrawCard(msg.playerid, deckid))
+  announce(deckNotification(deck, { status: 'Stacked', cards: cardDetails.length, location: placeOnTop ? 'Top' : 'Bottom' }))
 }
 
 on('ready', () => {

--- a/Scripts/General Scripts/API Commands/Card.js
+++ b/Scripts/General Scripts/API Commands/Card.js
@@ -89,7 +89,7 @@ function topCardFn([, whereToPlace], msg) {
                           )
 
   shuffleDeck(deckid, true, orderedList)
-  _.each(cardsInTheDiscard, cardInTheDiscard => drawCard(deckid))
+  _.each(cardsInTheDiscard, cardInTheDiscard => hackyDrawCard(msg.playerid, deckid))
 }
 
 on('ready', () => {

--- a/Scripts/General Scripts/API Commands/Deck.js
+++ b/Scripts/General Scripts/API Commands/Deck.js
@@ -118,7 +118,7 @@ function drawDeckFn(matches, msg) {
   var decks = suggestCMD(suggestion, deckPhrase, msg.playerid, 'deck', obj => playerIsGM(msg.playerid) || obj.get('showplayers'))
   if(!decks) return;
   var deck = decks[0]
-  var cardId = drawCard(deck.id)
+  var cardId = hackyDrawCard(msg.playerid,  deck.id)
   if(cardId) {
     var card = getObj('card', cardId)
     var maxCards = deck.get("_currentDeck").split(',').length
@@ -190,15 +190,13 @@ function playDeckFn(matches, msg, options) {
     playZone = getObj('graphic', options.playZoneId)
   }
 
-  const cardid = drawCard(deck.id)
+  const cardid = hackyDrawCard(msg.playerid,  deck.id)
   if(!cardid) {
     whisper(`WARNING: Deck ${deck.get('name')} has no more cards to play.`)
     return
   }
 
   fixedPlayCardToTable(cardid, { left: playZone.get('left'), top: playZone.get('top'), pageid: getPlayerPageID(msg.playerid)} )
-  giveCardToPlayer(cardid, msg.playerid)
-  takeCardFromPlayer(msg.playerid, { cardid: cardid })
   const card = getObj('card', cardid)
   if(options.announce) {
     announce(deckNotification(deck, {"card": card, "status": "Played"}))
@@ -230,7 +228,7 @@ function dumpDeckFn(matches, msg) {
   const playZone = playZones[0]
   const cardsToDump = deck.get("_cardSequencer");
   for(var dumpCount = 0; dumpCount < cardsToDump; dumpCount++) {
-    cardid = drawCard(deck.id)
+    cardid = hackyDrawCard(msg.playerid,  deck.id)
     fixedPlayCardToTable(cardid, { left: playZone.get('left'), top: playZone.get('top'), pageid: getPlayerPageID(msg.playerid)} )
   }
 

--- a/Scripts/General Scripts/API Commands/Deck.js
+++ b/Scripts/General Scripts/API Commands/Deck.js
@@ -197,6 +197,8 @@ function playDeckFn(matches, msg, options) {
   }
 
   fixedPlayCardToTable(cardid, { left: playZone.get('left'), top: playZone.get('top'), pageid: getPlayerPageID(msg.playerid)} )
+  giveCardToPlayer(cardid, msg.playerid)
+  takeCardFromPlayer(msg.playerid, { cardid: cardid })
   const card = getObj('card', cardid)
   if(options.announce) {
     announce(deckNotification(deck, {"card": card, "status": "Played"}))

--- a/Scripts/General Scripts/Functions/FixedPlayCardToTable.js
+++ b/Scripts/General Scripts/Functions/FixedPlayCardToTable.js
@@ -1,17 +1,16 @@
 const fixedPlayCardToTable = (cardid, options) => {
-        let card = getObj('card',cardid);
+        let card = getObj('card', cardid);
         if(card){
-            let deck = getObj('deck',card.get('deckid'));
+            let deck = getObj('deck', card.get('deckid'));
             if(deck){
-                if(!isCleanImgsrc(deck.get('avatar')) && !isCleanImgsrc(card.get('avatar'))){
-                    // marketplace-marketplace:
-                    playCardToTable(cardid, options);
-                } else if (isCleanImgsrc(deck.get('avatar')) && isCleanImgsrc(card.get('avatar'))){
+                const deckAvatar = options._deckAvatar || deck.get('avatar')
+                const cardAvatar = options._cardAvatar || card.get('avatar')
+                if (isCleanImgsrc(deckAvatar) && isCleanImgsrc(cardAvatar)){
                     let pageid = options.pageid || Campaign().get('playerpageid');
                     let page = getObj('page',pageid);
                     if(page){
 
-                        let imgs=[getCleanImgsrc(card.get('avatar')),getCleanImgsrc(deck.get('avatar'))];
+                        let imgs=[getCleanImgsrc(cardAvatar),getCleanImgsrc(deckAvatar)];
                         let currentSide = options.hasOwnProperty('currentSide')
                             ? options.currentSide
                             : ('faceup' === deck.get('cardsplayed')
@@ -45,6 +44,9 @@ const fixedPlayCardToTable = (cardid, options) => {
                     } else {
                         whisper(`Specified pageid does not exists.`);
                     }
+                } else if(!isCleanImgsrc(deck.get('avatar')) && !isCleanImgsrc(card.get('avatar'))) {
+                    // marketplace-marketplace:
+                    playCardToTable(cardid, options);
                 } else {
                     whisper(`Can't create cards for a deck mixing Marketplace and User Library images.`);
                 }

--- a/Scripts/General Scripts/Functions/GetPlayZone.js
+++ b/Scripts/General Scripts/Functions/GetPlayZone.js
@@ -1,0 +1,19 @@
+function getPlayZone(deckName, playerid) {
+  var pageid = getPlayerPageID(playerid)
+  const playZones = findObjs({
+    _type: 'graphic',
+    _pageid: pageid,
+    layer: 'gmlayer',
+    name: `${deckName} INK CardPlayer`
+  })
+
+  if(playZones == 0) {
+    whisper(`WARNING: The Deck ${deckName} does not have a designated play zone. Please contact your GM.`, {speakingTo: playerid})
+    return
+  } else if(playZones > 1) {
+    whisper(`WARNING: There is more than one play zone for the Deck ${deckName}. Plese contact your GM.`, {speakingTo: playerid})
+    return
+  }
+
+  return playZones[0]
+}

--- a/Scripts/General Scripts/Functions/HackyDrawCard.js
+++ b/Scripts/General Scripts/Functions/HackyDrawCard.js
@@ -1,0 +1,18 @@
+//Roll20 currently has a bug in drawCard. It does not change the state of the
+//deck for the deck object. However, the actual deck's state is changing. This
+//leads to the reality of the deck getting out of sync with the data that the
+//API has access to.
+
+//To hackily get around this bug, this function hands the card to a player,
+//takes the card from the player, and puts the card in the discard pile. Now
+//the deck understands that a card has been drawn from the deck and it is now
+//in the discard pile.
+function hackyDrawCard(playerid, deckid, inputCardid) {
+  const cardid = drawCard(deckid, inputCardid)
+  if(cardid) {
+    giveCardToPlayer(cardid, playerid)
+    takeCardFromPlayer(playerid, { cardid: cardid })
+  }
+
+  return cardid
+}

--- a/Scripts/Gloomhaven/API Commands/BlessAndCurse.js
+++ b/Scripts/Gloomhaven/API Commands/BlessAndCurse.js
@@ -45,5 +45,5 @@ on("ready", () => {
     }
 
     shuffleDeck(deck.id, false)
-  })
+  }, true)
 })

--- a/Scripts/Gloomhaven/API Commands/Event.js
+++ b/Scripts/Gloomhaven/API Commands/Event.js
@@ -1,0 +1,110 @@
+on('ready', () => {
+  CentralInput.addCMD(/^!\s*(city|road|rift)\s*play\s*$/i, ([, deckType], msg) => {
+    //get ACTIVE deck
+    const deckName = `${deckType.toTitleCase()} Events`
+    const activeDecks = findObjs({
+      _type: 'deck',
+      name: deckName
+    })
+
+    if(!activeDecks || !activeDecks.length) return whisper(`The ${deckName} deck does not exist. Please contact your GM.`, { speakingTo: msg.playerid})
+    const activeDeck = activeDecks[0]
+
+    //get BACK deck
+    const backDecks = findObjs({
+      _type: 'deck',
+      name: deckName + ' Back'
+    })
+
+    if(!backDecks || !backDecks.length) return whisper(`The ${deckName + ' Back'} deck does not exist. Please contact your GM.`, { speakingTo: msg.playerid})
+    const backDeck = backDecks[0]
+
+    //get playzone
+    const playZone = getPlayZone(deckName, msg.playerid)
+    if(!playZone) return;
+
+    //draw top of ACTIVE deck
+    const activeCardid = hackyDrawCard(msg.playerid, activeDeck.id)
+    if(!activeCardid) return whisper(`Failed to draw a card from ${deckName}. Please shuffle with [!deck shuffle ${deckName}](!deck shuffle ${deckName}) and try again.`, { speakingTo: msg.playerid })
+    const activeCard = getObj('card', activeCardid)
+
+    //get matching card from BACK deck
+    const cardBacks = findObjs({
+      _type: 'card',
+      _deckid: backDeck.id,
+      name: activeCard.get('name')
+    })
+
+    if(!cardBacks || !cardBacks.length) return whisper(`Failed to find a card back for the card ${activeCard.get('name')} from the deck ${deckName} anywhere in the campaign. Please contact your GM.`)
+    const cardBack = cardBacks[0]
+
+    //play ACTIVE card to playZone but override cardBack
+    fixedPlayCardToTable(activeCardid, { left: playZone.get('left'), top: playZone.get('top'), pageid: playZone.get('_pageid'), _deckAvatar: cardBack.get('avatar') })
+    announce(deckNotification(activeDeck, { card: activeCard, status: 'Played' }))
+  }, true)
+
+  CentralInput.addCMD(/^!\s*(city|road|rift)\s*add\s*(\w+)\s*$/i, ([, deckType, cardName], msg) => {
+    //get ACTIVE deck
+    const deckName = `${deckType.toTitleCase()} Events`
+    const activeDecks = findObjs({
+      _type: 'deck',
+      name: deckName
+    })
+
+    if(!activeDecks || !activeDecks.length) return whisper(`The ${deckName} deck does not exist. Please contact your GM.`, { speakingTo: msg.playerid})
+    const activeDeck = activeDecks[0]
+
+    //get FRONT deck
+    const frontDecks = findObjs({
+      _type: 'deck',
+      name: deckName + ' Front'
+    })
+
+    if(!frontDecks || !frontDecks.length) return whisper(`The ${deckName + ' Front'} deck does not exist. Please contact your GM.`, { speakingTo: msg.playerid})
+    const frontDeck = frontDecks[0]
+
+    //get selected card from the FRONT deck
+    const cardFronts = findObjs({
+      _type: 'card',
+      _deckid: frontDeck.id,
+      name: cardName
+    })
+
+    if(!cardFronts || !cardFronts.length) return whisper(`Failed to find a card front for the card ${cardName} from the deck ${frontDeck} anywhere in the campaign. Please contact your GM.`)
+    const cardFront = cardFronts[0]
+
+    //add the card to the ACTIVE deck
+    const addedCard = createObj('card', {
+      _deckid: activeDeck.id,
+      name: cardFront.get('name'),
+      avatar: getCleanImgsrc(cardFront.get('avatar'))
+    });
+    shuffleDeck(activeDeck.id)
+    announce(deckNotification(activeDeck, { card: addedCard, status: 'Added' }))
+  }, true)
+
+  CentralInput.addCMD(/^!\s*(city|road|rift)\s*remove\s*$/i, ([, deckType, cardName], msg) => {
+    //get ACTIVE deck
+    const deckName = `${deckType.toTitleCase()} Events`
+    const activeDecks = findObjs({
+      _type: 'deck',
+      name: deckName
+    })
+
+    if(!activeDecks || !activeDecks.length) return whisper(`The ${deckName} deck does not exist. Please contact your GM.`, { speakingTo: msg.playerid})
+    const activeDeck = activeDecks[0]
+
+    //remove cards if they belong to the event deck
+    eachCard(msg, (character, graphic, card, deck) => {
+      if(deck.id == activeDeck.id) {
+        whisper(deckNotification(deck, {"card": card, "status": "Removed"}), {speakingTo: msg.playerid, gmEcho: true})
+        card.remove()
+        graphic.remove()
+      } else {
+        whisper(`The card ${card.get('name')} does not belong to the deck ${activeDeck.get('name')}. Skipping removal of that card.`)
+      }
+    }, { min: 1 })
+  }, true)
+
+  CentralInput.addCMD(/^!\s*(?:city|road|rift)\s*(bottom)\s*$/i, topCardFn, true)
+})

--- a/Scripts/Gloomhaven/API Commands/GiveTokenToCharacter.js
+++ b/Scripts/Gloomhaven/API Commands/GiveTokenToCharacter.js
@@ -1,0 +1,33 @@
+function giveTokenToCharacter([, isPlayer, name], msg){
+  //get the selected token
+  let graphic
+  if(msg.selected && msg.selected.length == 1){
+    graphic = getObj('graphic', msg.selected[0]._id);
+    if(graphic == undefined) return whisper('graphic undefined');
+  } else {
+    return whisper('Please select exactly one graphic.');
+  }
+
+  let characters = suggestCMD('!Give Token To $', name, msg.playerid, 'character');
+  if(!characters) return;
+  let character = characters[0];
+  graphic.set({
+    represents: character.id,
+    name: character.get('name'),
+    showname: true,
+    showplayers_name: true,
+    showplayers_bar1: true,
+    showplayers_bar2: true,
+    showplayers_bar3: true,
+    showplayers_aura1: true,
+    showplayers_aura2: true
+  });
+
+  setDefaultTokenForCharacter(character, graphic);
+  if(!character.get('avatar')) character.set('avatar', graphic.get('imgsrc').replace('/thumb.png?', '/med.png?'));
+  whisper('Default Token set for *' + getLink(character.get('name')) + '*.');
+}
+
+on('ready', function(){
+  CentralInput.addCMD(/^!\s*give\s*(|player)\s*token\s*to\s+(.+)$/i, giveTokenToCharacter);
+});

--- a/Scripts/Gloomhaven/API Commands/Scenario.js
+++ b/Scripts/Gloomhaven/API Commands/Scenario.js
@@ -1,88 +1,122 @@
+function gloomhavenSetRoundToOne() {
+  const turns = new INQTurns({ order: GLOOMHAVEN_INITIATIVE_ORDER })
+  turns.turnorder = [turns.toTurnObj('End of Round', 'R1')]
+  turns.save()
+  Campaign().set('initiativepage', Campaign().get('playerpageid'))
+}
+
+function gloomhavenSetScenarioDifficulty(difficulty, currentPlayers) {
+  let scenarioLevel;
+  if(/^\d+$/.test(difficulty)) {
+    scenarioLevel = Number(difficulty)
+  } else {
+    let totalLevel = 0
+    let totalCharacters = 0
+    _.each(currentPlayers, currentPlayer => {
+        const character = defaultCharacter(currentPlayer.id)
+        if(!character) return
+        const level = calcCharacterLevel(character.id)
+        if(!level) return
+        totalLevel += level
+        totalCharacters++
+    })
+
+    scenarioLevel = Math.ceil(totalLevel / (totalCharacters || 1) / 2)
+  }
+
+  if(/^easy$/i.test(difficulty)) {
+    scenarioLevel += -1
+  } else if(/^hard$/i.test(difficulty)) {
+    scenarioLevel += 1
+  } else if(/^very\s+hard$/i.test(difficulty)) {
+    scenarioLevel += 2
+  }
+
+  if(scenarioLevel < 0) {
+    scenarioLevel = 0
+  } else if(scenarioLevel > 7) {
+    scenarioLevel = 7
+  }
+
+  state.INK_GLOOMHAVEN.scenarioLevel = scenarioLevel
+}
+
+function gloomhavenDealBattleGoals(currentPlayers) {
+  const battleGoalDecks = findObjs({
+    _type: "deck",
+    name: "Battle Goals"
+  })
+
+  if(!battleGoalDecks && !battleGoalDecks.length) whisper('The Battle Goal deck does not exist. Please contact your GM.', { speakingTo: true})
+  const battleGoalDeckId = battleGoalDecks[0].id
+  recallCards(battleGoalDeckId)
+  shuffleDeck(battleGoalDeckId, true)
+  _.each(currentPlayers, currentPlayer => {
+    const firstCardid = drawCard(battleGoalDeckId)
+    giveCardToPlayer(firstCardid, currentPlayer.id)
+    const secondCardid = drawCard(battleGoalDeckId)
+    giveCardToPlayer(secondCardid, currentPlayer.id)
+  })
+}
+
+function gloomhavenHideInitiative(msg) {
+  const turns = new INQTurns({ order: GLOOMHAVEN_INITIATIVE_ORDER })
+  turns.turnorder = []
+  turns.save()
+  Campaign().set('initiativepage', false)
+  state.INK_GLOOMHAVEN = state.INK_GLOOMHAVEN || {}
+  state.INK_GLOOMHAVEN.playerInitiative = {}
+  _.each(state.INK_GLOOMHAVEN.monsterInitiative, (monsterInitDetails, deckid) => {
+    const statObj = getObj('graphic', monsterInitDetails.statId)
+    if(statObj) statObj.remove()
+    shuffleDeckFn([], msg, { deckid: deckid })
+  })
+
+  state.INK_GLOOMHAVEN.monsterInitiative = {}
+}
+
+function gloomhavenCleanDecks(msg) {
+  const modifierDecks = [
+    'Player 1 Modifiers',
+    'Player 2 Modifiers',
+    'Player 3 Modifiers',
+    'Player 4 Modifiers',
+    'Monster Modifiers',
+  ]
+  const temporaryCards = filterObjs(obj => {
+    if(obj.get('_type') != 'card') return false;
+    if(![
+      'Player Curse',
+      'Monster Curse',
+      'Bless',
+      'Penalty -1',
+    ].includes(obj.get('name'))) return false;
+    const deck = getObj('deck', obj.get('_deckid'))
+    if(!modifierDecks.includes(deck.get('name'))) return false;
+    return true;
+  })
+
+  _.each(temporaryCards, temporaryCard => temporaryCard.remove())
+  _.each(modifierDecks, modifierDeck => shuffleDeckFn([, modifierDeck], msg))
+}
+
 on('ready', () => {
   //start a scenario by setting the scenario level and resetting the Round tracker.
   CentralInput.addCMD(/^!\s*scenario\s+start\s*(|easy|normal|hard|very\s+hard|\d+)\s*$/i, ([, difficulty], msg) => {
-    const turns = new INQTurns({ order: GLOOMHAVEN_INITIATIVE_ORDER })
-    turns.turnorder = [turns.toTurnObj('End of Round', 'R1')]
-    turns.save()
-    Campaign().set('initiativepage', Campaign().get('playerpageid'))
-    let scenarioLevel;
-    if(/^\d+$/.test(difficulty)) {
-      scenarioLevel = Number(difficulty)
-    } else {
-      const currentPlayers = findObjs({
-        _type: 'player',
-        _online: true
-      })
-
-      let totalLevel = 0
-      let totalCharacters = 0
-      _.each(currentPlayers, currentPlayer => {
-          const character = defaultCharacter(currentPlayer.id)
-          if(!character) return
-          const level = calcCharacterLevel(character.id)
-          if(!level) return
-          totalLevel += level
-          totalCharacters++
-      })
-
-      scenarioLevel = Math.ceil(totalLevel / (totalCharacters || 1) / 2)
-    }
-
-    if(/^easy$/i.test(difficulty)) {
-      scenarioLevel += -1
-    } else if(/^hard$/i.test(difficulty)) {
-      scenarioLevel += 1
-    } else if(/^very\s+hard$/i.test(difficulty)) {
-      scenarioLevel += 2
-    }
-
-    if(scenarioLevel < 0) {
-      scenarioLevel = 0
-    } else if(scenarioLevel > 7) {
-      scenarioLevel = 7
-    }
-
-    state.INK_GLOOMHAVEN.scenarioLevel = scenarioLevel
+    const currentPlayers = findObjs({
+      _type: 'player',
+      _online: true
+    })
+    gloomhavenSetRoundToOne()
+    gloomhavenSetScenarioDifficulty(difficulty, currentPlayers)
+    gloomhavenDealBattleGoals(currentPlayers)
     announcePlan()
   }, true)
 
   //clear out an old scenario after it has ended
   CentralInput.addCMD(/^!\s*scenario?\s+end$/i, ([], msg) => {
-    const turns = new INQTurns({ order: GLOOMHAVEN_INITIATIVE_ORDER })
-    turns.turnorder = []
-    turns.save()
-    Campaign().set('initiativepage', false)
-    state.INK_GLOOMHAVEN = state.INK_GLOOMHAVEN || {}
-    state.INK_GLOOMHAVEN.playerInitiative = {}
-    _.each(state.INK_GLOOMHAVEN.monsterInitiative, (monsterInitDetails, deckid) => {
-      const statObj = getObj('graphic', monsterInitDetails.statId)
-      if(statObj) statObj.remove()
-      shuffleDeckFn([], msg, { deckid: deckid })
-    })
-
-    state.INK_GLOOMHAVEN.monsterInitiative = {}
-    const modifierDecks = [
-      'Player 1 Modifiers',
-      'Player 2 Modifiers',
-      'Player 3 Modifiers',
-      'Player 4 Modifiers',
-      'Monster Modifiers',
-    ]
-    const temporaryCards = filterObjs(obj => {
-      if(obj.get('_type') != 'card') return false;
-      if(![
-        'Player Curse',
-        'Monster Curse',
-        'Bless',
-        'Penalty -1',
-      ].includes(obj.get('name'))) return false;
-      const deck = getObj('deck', obj.get('_deckid'))
-      if(!modifierDecks.includes(deck.get('name'))) return false;
-      return true;
-    })
-
-    _.each(temporaryCards, temporaryCard => temporaryCard.remove())
-    _.each(modifierDecks, modifierDeck => shuffleDeckFn([, modifierDeck], msg))
+    gloomhavenHideInitiative(msg)
+    gloomhavenCleanDecks(msg)
     whisper('Scenario ended.', { speakingTo: msg.playerid })
   }, true);
 })

--- a/Scripts/Gloomhaven/API Commands/Scenario.js
+++ b/Scripts/Gloomhaven/API Commands/Scenario.js
@@ -44,7 +44,7 @@ on('ready', () => {
 
     state.INK_GLOOMHAVEN.scenarioLevel = scenarioLevel
     announcePlan()
-  })
+  }, true)
 
   //clear out an old scenario after it has ended
   CentralInput.addCMD(/^!\s*scenario?\s+end$/i, ([], msg) => {

--- a/Scripts/Gloomhaven/API Commands/Scenario.js
+++ b/Scripts/Gloomhaven/API Commands/Scenario.js
@@ -52,9 +52,9 @@ function gloomhavenDealBattleGoals(currentPlayers) {
   recallCards(battleGoalDeckId)
   shuffleDeck(battleGoalDeckId, true)
   _.each(currentPlayers, currentPlayer => {
-    const firstCardid = drawCard(battleGoalDeckId)
+    const firstCardid = hackyDrawCard(msg.playerid,  battleGoalDeckId)
     giveCardToPlayer(firstCardid, currentPlayer.id)
-    const secondCardid = drawCard(battleGoalDeckId)
+    const secondCardid = hackyDrawCard(msg.playerid,  battleGoalDeckId)
     giveCardToPlayer(secondCardid, currentPlayer.id)
   })
 }


### PR DESCRIPTION
Bug Fixes
* Allow players to use `!scenario start`
* Allow players to use `!deck bless`, `!deck curse`, `!deck penalize`
* Fix issue with Roll20 drawCard() not updating details of deck object.

New Features
* `!scenario start` deals out two Battle Goals to each online player.
* Added `!card top` and `!card bottom` for placing the selected cards on top/bottom of their deck in left to right order.
* Added `!(city|road|rift) play` to play the top card of the corresponding event deck to the playZone for that deck. However, instead of using the deck image for the back of the card, it will use the back of the matching card in the Event Backs deck. This creates a double sided token with a card front and card back unique to each card.
* Added `!(city|road|rift) add` to add a named card to the event deck. This prevents the user from having to search for the new card, pull it out, add a copy to the active pile, and put away the new card.
* Added `!(city|road|rift) remove` to remove the selected card from the event deck.
* Added `!(city|road|rift) bottom` to place an event back in its event deck but at the bottom of the deck.